### PR TITLE
Add bulk uncheck

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -177,6 +177,18 @@ components:
       required:
         - taskIds
 
+    TaskBulkUncheckInput:
+      type: object
+      properties:
+        taskIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: List of task IDs to uncheck
+      required:
+        - taskIds
+
     TaskMoveInput:
       type: object
       properties:
@@ -567,6 +579,51 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SuccessResponse"
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Category not found
+        "400":
+          description: Bad request
+
+  /categories/{categoryId}/tasks/bulk-uncheck:
+    parameters:
+      - name: categoryId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+        description: ID of the category containing the tasks
+
+    post:
+      summary: Uncheck multiple tasks at once
+      description: Marks multiple tasks as unchecked without changing their order in the list
+      operationId: bulkUncheckTasks
+      tags:
+        - Tasks
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TaskBulkUncheckInput"
+      responses:
+        "200":
+          description: Tasks unchecked successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  taskIds:
+                    type: array
+                    items:
+                      type: string
+                      format: uuid
+                    description: IDs of the tasks that were unchecked
         "401":
           description: Unauthorized
         "403":


### PR DESCRIPTION
This pull request introduces a new endpoint to uncheck multiple tasks at once in the `openapi.yaml` file. The changes include defining a new input schema and adding a new path to the API.

### New input schema:

* Added `TaskBulkUncheckInput` schema to define the structure for bulk unchecking tasks, which includes an array of task IDs.

### New API endpoint:

* Added the `/categories/{categoryId}/tasks/bulk-uncheck` path to allow unchecking multiple tasks at once. This path includes parameters for the category ID and a request body that references the new `TaskBulkUncheckInput` schema.